### PR TITLE
Support 'null' return values.

### DIFF
--- a/packages/docx-templates/src/jsSandbox.js
+++ b/packages/docx-templates/src/jsSandbox.js
@@ -100,8 +100,8 @@ const runUserJsAndGetRaw = async (
     result = context.__result__;
   }
 
-  // Wait for pormises to resolve
-  if (typeof result === 'object' && result.then) result = await result;
+  // Wait for promises to resolve
+  if (typeof result === 'object' && result && result.then) result = await result;
 
   // Save the sandbox for later use
   ctx.jsSandbox = omit(context, ['__code__', '__result__']);


### PR DESCRIPTION
typeof null === 'object'. Therefore if a script expression is evaluated to null, this line threw an error when trying to access the property 'then' of null.