### PR TITLE
Fix for missing image extension

### DIFF
--- a/packages/docx-templates/src/mainBrowser.js
+++ b/packages/docx-templates/src/mainBrowser.js
@@ -275,7 +275,7 @@ const processImages = async (images, documentComponent, zip, templatePath) => {
     for (let i = 0; i < imageIds.length; i++) {
       const imageId = imageIds[i];
       const { extension, data: imgData } = images[imageId];
-      const imgName = `template_${documentComponent}_image${i + 1}${extension}`;
+      const imgName = `template_${documentComponent}_image${i + 1}.${extension}`;
       DEBUG && log.debug(`Writing image ${imageId} (${imgName})...`);
       const imgPath = `${templatePath}/media/${imgName}`;
       if (typeof imgData === 'string') {


### PR DESCRIPTION
Upon opening a document with images, it gives the following warning:
![imgpsh_mobile_save](https://user-images.githubusercontent.com/5529244/49162215-b2dffd80-f32a-11e8-910c-f21cea7d8c55.jpeg)

Opening the docx to see whats inside, shows that (after some tests) the cause is a missing image extension:
![imgpsh_mobile_save 1](https://user-images.githubusercontent.com/5529244/49162350-fc304d00-f32a-11e8-902c-1894e313401c.jpeg)