### PR TITLE
Fixed error handling in getRelsfromZip

### DIFF
--- a/packages/docx-templates/src/mainBrowser.js
+++ b/packages/docx-templates/src/mainBrowser.js
@@ -366,10 +366,8 @@ const processHtmls = async (htmls, documentComponent, zip, templatePath) => {
 };
 
 const getRelsFromZip = async (zip, relsPath) => {
-  let relsXml;
-  try {
-    relsXml = await zipGetText(zip, relsPath);
-  } catch (err) {
+  let relsXml = await zipGetText(zip, relsPath);
+  if (!relsXml) {
     relsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
         </Relationships>`;


### PR DESCRIPTION
zipGetText does not throw an exception yet, instead returns with
null. getRelsFromZip now uses null checking for error handling.

It caused error for example with docx-templates/packages/example-node/images-pathHeader.docx sample.
