### PR TITLE
Support for begin delimiter and end delimiter, INS as default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage
 # ------------
 # All projects
 lib
+dist
 
 # Project-specific
 **/__tests__/fixtures/*_report.docx

--- a/packages/docx-templates/README.md
+++ b/packages/docx-templates/README.md
@@ -1,3 +1,18 @@
+# This is a fork
+This fork is for a simple and compact `INS` syntax which you can omit `=` or `INS`. For example: from `+++=foo+++` to `|foo|`.
+Also, you can define `cmdDelimiter` as an Array containing start and end delimiter. For example:
+```
+createReport({
+  // ...
+  cmdDelimiter: ['{','}'],
+})
+```
+then you can use this form in the docx file:
+```
+{foo}
+```
+Also, add `dist/docxt.min.js` file so you can directly use it in browser.
+
 # Docx-templates [![Build Status](https://travis-ci.org/guigrpa/docx-templates.svg)](https://travis-ci.org/guigrpa/docx-templates) [![Coverage Status](https://coveralls.io/repos/github/guigrpa/docx-templates/badge.svg?branch=master)](https://coveralls.io/github/guigrpa/docx-templates?branch=master) [![npm version](https://img.shields.io/npm/v/docx-templates.svg)](https://www.npmjs.com/package/docx-templates)
 
 Template-based docx report creation for both Node and the browser. ([See the blog post](http://guigrpa.github.io/2017/01/01/word-docs-the-relay-way/)).

--- a/packages/docx-templates/package.json
+++ b/packages/docx-templates/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "docx-templates",
-  "version": "3.0.0",
-  "description": "Template-based docx report creation",
+  "name": "docxt",
+  "version": "3.0.5",
+  "description": "Template-based docx report creation (a fork)",
   "main": "lib/indexNode.js",
   "browser": "lib/indexBrowser.js",
   "author": "Guillermo Grau Panea",
@@ -14,13 +14,13 @@
     "report",
     "template"
   ],
-  "homepage": "https://github.com/guigrpa/docx-templates#readme",
+  "homepage": "https://github.com/xiangnanscu/docx-templates#readme",
   "bugs": {
-    "url": "https://github.com/guigrpa/docx-templates/issues"
+    "url": "https://github.com/xiangnanscu/docx-templates/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guigrpa/docx-templates.git"
+    "url": "git+https://github.com/xiangnanscu/docx-templates.git"
   },
   "scripts": {
     "compile": "yarn compile:prepare && yarn compile:copy && yarn compile:run",

--- a/packages/docx-templates/package.json
+++ b/packages/docx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docxt",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Template-based docx report creation (a fork)",
   "main": "lib/indexNode.js",
   "browser": "lib/indexBrowser.js",
@@ -30,6 +30,8 @@
     "compile:run": "babel --out-dir lib --ignore \"**/__mocks__/**\",\"**/__tests__/**\" src",
     "start": "cd examples/swapi && node swapi-node swapi-complex.docx",
     "travis": "yarn compile && yarn test",
+    "dist": "browserify lib/indexNode.js | babel -f .babelrc | uglifyjs > dist/docxt.min.js",
+    "release": "yarn compile && rm -f lib/*.flow && yarn dist",
     "jest": "jest --watch --coverage",
     "test": "yarn testCovFull",
     "testCovFull": "yarn testCovPrepare && yarn testDev && yarn testCovReport",

--- a/packages/docx-templates/src/debug.js
+++ b/packages/docx-templates/src/debug.js
@@ -1,9 +1,12 @@
+// Baby, I don't need these debug tools but it keeps annoying me in
+// production mode, so I comment them.
+
 // Cannot be covered by Flow! The purpose of this file is to isolate
 // an optional dependency, only used in development (so that Flow
 // doesn't throw errors when processing users' projects)
-import { mainStory, chalk, addListener } from 'storyboard';
-import consoleListener from 'storyboard-listener-console';
+// import { mainStory, chalk, addListener } from 'storyboard';
+// import consoleListener from 'storyboard-listener-console';
 
-addListener(consoleListener);
+// addListener(consoleListener);
 
 export { mainStory, chalk };

--- a/packages/docx-templates/src/indexNode.js
+++ b/packages/docx-templates/src/indexNode.js
@@ -1,4 +1,13 @@
-const createReport = require('./mainNode').default;
-
-module.exports = createReport;
-module.exports.default = createReport;
+(function (global, factory) {
+  if (typeof exports === 'object' && typeof module !== 'undefined'){
+    module.exports = factory()
+    module.exports.default = factory()
+  } else if(typeof define === 'function' && define.amd) {
+    define(factory)
+  } else {
+    global = global || self
+    global.createReport = factory();
+  }
+}(this, function () {
+  return require('./mainNode').default;
+}))

--- a/packages/docx-templates/src/mainBrowser.js
+++ b/packages/docx-templates/src/mainBrowser.js
@@ -28,6 +28,15 @@ const chalk: any = DEBUG ? require('./debug').chalk : null;
 // ==========================================
 // Main
 // ==========================================
+const getCmdDelimiter = (delimiter) => {
+  if (!delimiter) {
+    return [DEFAULT_CMD_DELIMITER, DEFAULT_CMD_DELIMITER];
+  } else if (typeof delimiter == 'string') {
+    return [delimiter, delimiter];
+  } else {
+    return delimiter
+  }
+}
 const createReport = async (options: UserOptionsInternal) => {
   DEBUG && log.debug('Report options:', { attach: options });
   const { template, data, queryVars, _probe } = options;
@@ -35,7 +44,7 @@ const createReport = async (options: UserOptionsInternal) => {
   const literalXmlDelimiter =
     options.literalXmlDelimiter || DEFAULT_LITERAL_XML_DELIMITER;
   const createOptions = {
-    cmdDelimiter: options.cmdDelimiter || DEFAULT_CMD_DELIMITER,
+    cmdDelimiter: getCmdDelimiter(options.cmdDelimiter),
     literalXmlDelimiter,
     processLineBreaks:
       options.processLineBreaks != null ? options.processLineBreaks : true,

--- a/packages/docx-templates/src/processTemplate.js
+++ b/packages/docx-templates/src/processTemplate.js
@@ -500,7 +500,7 @@ const processCmd = async (
 const builtInCommands = ['HTML','LINK','IMAGE','EXEC','INS','END-FOR','END-IF',
   'FOR','IF','ALIAS','QUERY','CMD_NODE'];
 const notBuiltIns = (cmd) => {
-  return !builtInCommands.some(word=>new RegExp(`^${word}\\s`)
+  return !builtInCommands.some(word=>new RegExp(`^${word}`)
     .test(cmd.toUpperCase()));
 };
 const getCommand = (ctx: Context): string => {

--- a/packages/docx-templates/src/types.js
+++ b/packages/docx-templates/src/types.js
@@ -53,7 +53,7 @@ export type UserOptionsInternal = {|
 |};
 
 export type CreateReportOptions = {|
-  cmdDelimiter: string,
+  cmdDelimiter: string|Object,
   literalXmlDelimiter: string,
   processLineBreaks: boolean,
   noSandbox: boolean,


### PR DESCRIPTION
Hello, docx-templates is really powerful. It would be really really great if  begin delimiter and end delimiter are support. Something like providing a pair of delimiters in createReport kwargs **and** treat empty string command as `INS`:
```
  const report = await createReport({
    cmdDelimiter: ['{', '}'], // can now be an array containing two elements.
    // cmdDelimiter: '+++', // you can also provide a string, which is equivalent to ['+++', '+++']
    literalXmlDelimiter: '||',
    processLineBreaks: true,
    noSandbox: false,
    data: {foo:'hello', bar:'world'},})
```
and then in the docx template, write like this:
```
{foo}
{bar}
```
which is equivalent to :
```
{=foo}
{=bar}
```
which is  equivalent to (current version):
```
+++=foo+++
+++=bar+++
```
