### PR TITLE
Fix built in detection

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -551,7 +551,9 @@ const builtInCommands = [
   'HTML',
 ];
 const notBuiltIns = (cmd: string) =>
-  !builtInCommands.some(word => new RegExp(`^${word}`).test(cmd.toUpperCase()));
+  !builtInCommands.some(word =>
+    new RegExp(`^${word}\\b`).test(cmd.toUpperCase())
+  );
 
 const getCommand = (ctx: Context): string => {
   let { cmd } = ctx;


### PR DESCRIPTION
Variable names starting with a built in, will be detected as a built in.
So this does not work: `+++formatNumber(123)+++`. It is detected to use `FOR`.

notBuiltIns before change:
```
new RegExp(`^FOR`).test("FOR") // true
new RegExp(`^FOR`).test("FOR ") // true
new RegExp(`^FOR`).test("FOR\n") // true
new RegExp(`^FOR`).test("FORMAT\n") // true
new RegExp(`^FOR`).test("OTHER\n") // false
```

notBuiltIns after change:
```
new RegExp(`^FOR\\b`).test("FOR") // true
new RegExp(`^FOR\\b`).test("FOR ") // true
new RegExp(`^FOR\\b`).test("FOR\n") // true
new RegExp(`^FOR\\b`).test("FORMAT\n") // false
new RegExp(`^FOR\\b`).test("OTHER\n") // false
```