### PR TITLE
Add custom errorHandler option during template generation

### DIFF
--- a/src/jsSandbox.ts
+++ b/src/jsSandbox.ts
@@ -60,7 +60,13 @@ export async function runUserJsAndGetRaw(
       result = context.__result__;
     }
   } catch (err) {
-    throw new CommandExecutionError(err.toString(), code);
+    try {
+      if (typeof ctx.options.errorHandler === 'function') {
+        return ctx.options.errorHandler(err, code);
+      } else throw false;
+    } catch (err2) {
+      throw new CommandExecutionError(err.toString(), code);
+    }
   }
 
   // Wait for promises to resolve

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,8 @@ async function createReport(
     failFast: options.failFast == null ? true : options.failFast,
     rejectNullish:
       options.rejectNullish == null ? false : options.rejectNullish,
+    errorHandler:
+      typeof options.errorHandler === 'function' ? options.errorHandler : null,
   };
   const xmlOptions = { literalXmlDelimiter };
 
@@ -304,6 +306,7 @@ export async function listCommands(
     additionalJsContext: {},
     failFast: false,
     rejectNullish: false,
+    errorHandler: null,
   };
 
   const { jsTemplate } = await parseTemplate(template);

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -569,8 +569,15 @@ const processCmd: CommandProcessor = async (
       // Invalid command
     } else throw new CommandSyntaxError(cmd);
     return;
-  } catch (err) {
-    return err;
+  } catch (e) {
+    if (typeof ctx.options.errorHandler === 'function') {
+      const result = ctx.options.errorHandler(e);
+      return result;
+    } else {
+      return e;
+    }
+
+    // return err;
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export type QueryResolver = (
   queryVars: any
 ) => ReportData | Promise<ReportData>;
 
+export type errorHandler = (e: Error, rawcode?: Object) => any;
+
 type RunJSFunc = (o: {
   sandbox: Object;
   ctx: Object;
@@ -100,6 +102,10 @@ export type UserOptions = {
    * When set to `true`, this setting ensures `createReport` throws a `NullishCommandResultError` when the result of an INS, HTML, IMAGE, or LINK command is `null` or `undefined`. This is useful as nullish return values usually indicate a mistake in the template or the invoking code. Defaults to `false`.
    */
   rejectNullish?: boolean;
+  /**
+   * Custom error handler
+   */
+  errorHandler?: errorHandler;
 };
 
 export type CreateReportOptions = {
@@ -111,6 +117,7 @@ export type CreateReportOptions = {
   additionalJsContext: Object;
   failFast: boolean;
   rejectNullish: boolean;
+  errorHandler: errorHandler | null;
 };
 
 export type Context = {


### PR DESCRIPTION
I added an additional errorHandler option to catch *all* sandboxed errors (see #138)

I didn't replace the rejectNullish option because the 'undefined' errors are runtime errors thrown by the sandbox, and the rejectNullish errors require a clean execution in the sandbox. 