### PR TITLE
fix smart quotes in commands

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -588,6 +588,10 @@ export function getCommand(
   } else if (notBuiltIns(cmd)) {
     cmd = `INS ${cmd.trim()}`;
   }
+  
+  //replace 'smart' quotes with straight quotes
+  cmd = cmd.replace(/[\u201C\u201D\u201E]/g, '"').replace(/[\u2018\u2019\u201A]/g, "'");
+  
   return cmd.trim();
 }
 


### PR DESCRIPTION
I have an issue where I need to run a command in a template, where one of the arguments takes a string. Problem is when MS Word takes over, it adds smart quotes to the argument list, and the JSSandbox errors out. 

I've added a line to replace the unicode 'smart' quotes, and replace them with straight quotes.

My use Case: 
```
{ IMAGE signature(“speedpro”) } //errors out because of curly quotes being in the execution context
```

Maybe we also want to include a flag in the options to make this behaviour optional?
