### PR TITLE
line breaks implementation change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,10 @@ async function createReport(
       typeof options.errorHandler === 'function' ? options.errorHandler : null,
     fixSmartQuotes:
       options.fixSmartQuotes == null ? false : options.fixSmartQuotes,
+    processLineBreaksAsNewText:
+      options.processLineBreaksAsNewText == null
+        ? false
+        : options.processLineBreaksAsNewText,
   };
   const xmlOptions = { literalXmlDelimiter };
 
@@ -310,6 +314,7 @@ export async function listCommands(
     rejectNullish: false,
     errorHandler: null,
     fixSmartQuotes: false,
+    processLineBreaksAsNewText: false,
   };
 
   const { jsTemplate } = await parseTemplate(template);

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -503,11 +503,24 @@ const processCmd: CommandProcessor = async (
         // the `literalXmlDelimiter` separators)
         let str = String(result);
         if (ctx.options.processLineBreaks) {
-          const { literalXmlDelimiter } = ctx.options;
-          str = str.replace(
-            /\n/g,
-            `${literalXmlDelimiter}<w:br/>${literalXmlDelimiter}`
-          );
+          const {
+            literalXmlDelimiter,
+            processLineBreaksAsNewText,
+          } = ctx.options;
+          if (ctx.options.processLineBreaksAsNewText) {
+            const splitByLineBreak = str.split('\n');
+            const LINE_BREAK = `${literalXmlDelimiter}<w:br/>${literalXmlDelimiter}`;
+            const END_OF_TEXT = `${literalXmlDelimiter}</w:t>${literalXmlDelimiter}`;
+            const START_OF_TEXT = `${literalXmlDelimiter}<w:t xml:space="preserve">${literalXmlDelimiter}`;
+            str = splitByLineBreak.join(
+              `${END_OF_TEXT}${LINE_BREAK}${START_OF_TEXT}`
+            );
+          } else {
+            str = str.replace(
+              /\n/g,
+              `${literalXmlDelimiter}<w:br/>${literalXmlDelimiter}`
+            );
+          }
         }
         return str;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,8 @@ export type UserOptions = {
    * Defaults to false.
    */
   fixSmartQuotes?: boolean;
+
+  processLineBreaksAsNewText?: boolean;
 };
 
 export type CreateReportOptions = {
@@ -128,6 +130,7 @@ export type CreateReportOptions = {
   rejectNullish: boolean;
   errorHandler: ErrorHandler | null;
   fixSmartQuotes: boolean;
+  processLineBreaksAsNewText: boolean;
 };
 
 export type Context = {


### PR DESCRIPTION
Hi there!
I run this company iva-docs.com. The product is very straight forward, give us a template, we'll connect it to your data sources (Zapier, Typeform, Webhooks) and we'll deliver it where you want (Google drive, Email...).
I've looked at the current implementation of line breaks, and for some reason, it doesn't render properly in the Docx.
The output of this string:
```javascript
const str = ` Love
Will
Always
Win`
```

is:

```XML
<w:r>
<w:t>
love <w:br/>will <w:br/> Always <w:br/> Win 
</w:t>
</w:r>
```


for some reason, it doesn't display properly.
So my suggestion (and what worked for me) is:


```xml
<w:r>
<w:t>
love
</w:t>
 <w:br/>
<w:t>
will
</w:t>
<w:br/>
<w:t>
Always
</w:t>
<w:br/>
<w:t>
Win
</w:t> 
</w:r>
```
I've then added this new implementation as an option in the CreateReportOptions. But I'm not sure if that's how you see it implemented.
I've setup this implementation in Iva and currently testing it in production. No Issues so far.
I'm available if you need anything
