### PR TITLE
XML command

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,26 @@ Takes the HTML resulting from evaluating a JavaScript snippet and converts it to
 `+++
 ```
 
+### `XML`
+
+Takes the literal XML resulting from evaluating a JavaScript snippet and insert it to Word directly. It is alternative way of using literalXml delimeter:
+
+```
++++XML `
+<w:p><w:r><w:t>Created by literal XML command</w:t></w:r></w:p>
+`+++
+```
+If literal XML has more than one root, please wrap it under &lt;fragment/> root element:
+```
++++XML `
+<fragment>
+  <w:p><w:r><w:t>First paragraph</w:t></w:r></w:p>
+  <w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p>
+  ...
+</fragment>
+`+++
+```
+
 ### `FOR` and `END-FOR`
 
 Loop over a group of elements (resulting from the evaluation of a JavaScript expression):

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -31,6 +31,7 @@ import {
   ObjectCommandResultError,
 } from './errors';
 import { logger } from './debug';
+import { parseXml } from './xml';
 
 export function newContext(options: CreateReportOptions, imageId = 0): Context {
   return {
@@ -312,6 +313,32 @@ export async function walkTemplate(
         delete ctx.pendingHtmlNode;
       }
 
+      // Replace the parent `w:p` node with the xml node(s)
+      if (
+        ctx.pendingXmlNode &&
+        !nodeOut._fTextNode && // Flow-prevention
+        nodeOut._tag === 'w:p'
+      ) {
+        const xmlNode = ctx.pendingXmlNode;
+        const parent = nodeOut._parent;
+        if (parent) {
+          xmlNode._parent = parent;
+          parent._children.pop();
+          // check for fragment node
+          if (!xmlNode._fTextNode && xmlNode._tag === 'fragment') {
+            xmlNode._children.forEach(childNode => {
+              parent._children.push(childNode)
+            })
+          } else {
+            parent._children.push(xmlNode);
+          }
+          // Prevent containing paragraph or table row from being removed
+          ctx.buffers['w:p'].fInsertedText = true;
+          ctx.buffers['w:tr'].fInsertedText = true;
+        }
+        delete ctx.pendingXmlNode;
+      }
+
       // `w:tc` nodes shouldn't be left with no `w:p` children; if that's the
       // case, add an empty `w:p` inside
       if (
@@ -583,6 +610,17 @@ const processCmd: CommandProcessor = async (
           ctx
         );
         if (html != null) await processHtml(ctx, html);
+      }
+
+     // XML <code>
+    } else if (cmdName === 'XML') {
+      if (!isLoopExploring(ctx)) {
+        const xml: string | undefined = await runUserJsAndGetRaw(
+          data,
+          cmdRest,
+          ctx
+        );
+        if (xml != null) await processXml(ctx, xml);
       }
 
       // Invalid command
@@ -922,6 +960,11 @@ const processHtml = async (ctx: Context, data: string) => {
   const node = newNonTextNode;
   const html = node('w:altChunk', { 'r:id': relId });
   ctx.pendingHtmlNode = html;
+};
+
+const processXml = async (ctx: Context, data: string) => {
+  const xml = await parseXml(data);
+  ctx.pendingXmlNode = xml;
 };
 
 // ==========================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,7 @@ export type Context = {
   options: CreateReportOptions;
   jsSandbox?: Object;
   textRunPropsNode?: NonTextNode;
+  pendingXmlNode?: Node;
 };
 
 export type Images = { [id: string]: Image };
@@ -247,4 +248,5 @@ export const BUILT_IN_COMMANDS = [
   'IMAGE',
   'LINK',
   'HTML',
+  'XML',
 ] as const;


### PR DESCRIPTION
I use literalXml alot with this [workaround](https://github.com/guigrpa/docx-templates/issues/16#issuecomment-392001823). It really useful in many circumstances. However, it adds extra 2 paragraphs before and after insertion point which is not ideal. So I came up with this additional XML command, that once inserted, replace existing paragraph the same way other commands did (LINK, IMAGE, HTML).

The literal XML need special treatment if it contains multiple root elements (fragment). I opt to put them under a <fragment/> root element and add them up to the xml node tree if the <fragment/> root presented.