### PR TITLE
Replace dot with underscore in HTML name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -520,7 +520,7 @@ const processHtmls = async (
     const rels = await getRelsFromZip(zip, relsPath);
     for (const htmlId of htmlIds) {
       const htmlData = htmls[htmlId];
-      const htmlName = `template_${documentComponent}_${htmlId}.html`;
+      const htmlName = `template_${documentComponent.replace('.', '_')}_${htmlId}.html`;
       logger.debug(`Writing html ${htmlId} (${htmlName})...`);
       const htmlPath = `${templatePath}/${htmlName}`;
       htmlFiles.push(`/${htmlPath}`);


### PR DESCRIPTION
I used `docx-templates` to generate a Word document with embedded HTML (altchunks). I was unable to open the document using Docx4j. The following error was reported:

```
org.docx4j.openpackaging.exceptions.Docx4JException: For source /word/document.xml, cannot find part word/template_document.xml_html1.html from rel html1=template_document.xml_html1.html
        at org.docx4j.openpackaging.io3.Load3.getRawPart(Load3.java:626)
        at org.docx4j.openpackaging.io3.Load3.getPart(Load3.java:372)
```

After unzipping the Word document, I noticed there were a bunch of files in the `word` folder that were named like this:

```
template_document.xml_html1.html
template_document.xml_html2.html
template_document.xml_html3.html
```

Since each file name contained two dots in it, I renamed them by replacing the first dot with an underscore:

 ```
template_document_xml_html1.html
template_document_xml_html2.html
template_document_xml_html3.html
```

After renaming the files, I zipped up the folder, and was then able to open the Word document in Docx4j.

This pull request contains a single line of code to ensure the first dot in the HTML file name is replaced with an underscore. Not sure if the file names could end up with multiple dots, so a regex global replace would probably be a better solution.