### PR TITLE
Prevent adding empty paragraph if cell contains altChunk

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -312,12 +312,12 @@ export async function walkTemplate(
         delete ctx.pendingHtmlNode;
       }
 
-      // `w:tc` nodes shouldn't be left with no `w:p` children; if that's the
+      // `w:tc` nodes shouldn't be left with no `w:p` or 'w:altChunk' children; if that's the
       // case, add an empty `w:p` inside
       if (
         !nodeOut._fTextNode && // Flow-prevention
         nodeOut._tag === 'w:tc' &&
-        !nodeOut._children.filter(o => !o._fTextNode && o._tag === 'w:p').length
+        !nodeOut._children.filter(o => !o._fTextNode && (o._tag === 'w:p' || o._tag === 'w:altChunk')).length
       ) {
         nodeOut._children.push({
           _parent: nodeOut,


### PR DESCRIPTION
I used docx-templates to generate a Word document with embedded HTML (altchunks) within cells of a table. In the generated document, I found that each of these cells ended up with extra whitespace beneath the HTML content.

![image](https://user-images.githubusercontent.com/2073827/130186121-e4341d26-4aea-4e04-be5f-d77f3da97c9e.png)

I tracked it down to the code that adds a `<w:p/>` if it finds that the table cell does not already contain a `<w:p/>`. This PR builds on that, by also checking to make sure the table cell does also not already contain a `<w:altChunk>`.

After generating the same Word document again, using this PR, the embedded HTML no longer contains extra whitespace beneath the HTML content.