### PR TITLE
Add support for Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Check out the [Node examples folder](https://github.com/guigrpa/docx-templates/t
 You can use docx-templates in Deno! Just follow the Browser guide and import the polyfilled docx-templates bundle for example from unpkg!
 
 ```ts
-// @deno-types="https://unpkg.com/docx-templates/lib/index.d.ts"
+// @deno-types="https://unpkg.com/docx-templates/lib/bundled.d.ts"
 import { createReport } from 'https://unpkg.com/docx-templates/lib/browser.js';
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ const report = await createReport({
 
 Check out the [Node examples folder](https://github.com/guigrpa/docx-templates/tree/master/examples/example-node).
 
+# Deno usage
+You can use docx-templates in Deno! Just follow the Browser guide and import the polyfilled docx-templates bundle for example from unpkg!
+
+```ts
+// @deno-types="https://unpkg.com/docx-templates/lib/index.d.ts"
+import { createReport } from 'https://unpkg.com/docx-templates/lib/browser.js';
+```
 
 # Browser usage
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/guigrpa/docx-templates.git"
   },
   "scripts": {
-    "compile": "rimraf ./lib && yarn rollup && tsc",
+    "compile": "rimraf ./lib && tsc && yarn rollup",
     "rollup": "rollup -c",
     "prepack": "yarn compile",
     "travis": "yarn compile && yarn test",
@@ -70,6 +70,7 @@
     "qrcode": "^1.4.4",
     "rimraf": "^3.0.2",
     "rollup": "^2.56.0",
+    "rollup-plugin-dts": "^4.1.0",
     "rollup-plugin-esbuild": "^4.5.0",
     "stream-browserify": "^3.0.0",
     "ts-jest": "^27.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,9 +2,10 @@ import replace from '@rollup/plugin-replace'
 import esbuild from 'rollup-plugin-esbuild'
 import node from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
+import dts from 'rollup-plugin-dts'
 
 
-export default {
+export default [{
   input: './src/browser.ts',
   output: { file: './lib/browser.js', format: 'es', exports: 'named', sourcemap: true },
   plugins: [
@@ -43,4 +44,8 @@ export default {
       }
     }
   ]
-}
+}, {
+  input: './lib/index.d.ts',
+  output: {file: './lib/bundled.d.ts', format: 'es'},
+  plugins: [dts()]
+}]

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,7 +185,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3", "@babel/parser@^7.7.2":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.7.2":
+  version "7.14.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
+  integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.16.0", "@babel/parser@^7.16.3":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
@@ -3896,6 +3901,15 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-dts@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-4.1.0.tgz#63b1e7de3970bb6d50877e60df2150a3892bc49c"
+  integrity sha512-rriXIm3jdUiYeiAAd1Fv+x2AxK6Kq6IybB2Z/IdoAW95fb4uRUurYsEYKa8L1seedezDeJhy8cfo8FEL9aZzqg==
+  dependencies:
+    magic-string "^0.25.7"
+  optionalDependencies:
+    "@babel/code-frame" "^7.16.0"
 
 rollup-plugin-esbuild@^4.5.0:
   version "4.7.2"


### PR DESCRIPTION
This PR add some info for Deno in the README. (For Deno the polyfiled Browser-Bundle works!)

For types to work (as deno requires full filenames so the extension can't be omited) I added a build step to bundle all types into a single file so no refrences to other files are needed. This ADDS a single bundle.d.ts file in the npm package so we can tell deno to use the specific types.