### PR TITLE
fix: deno types

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ You can use docx-templates in Deno! Just follow the Browser guide and import the
 import { createReport } from 'https://unpkg.com/docx-templates/lib/browser.js';
 ```
 
+> Note that you have to set `noSandbox: true` or bring your own sandbox with the `runJs` option.
+
 # Browser usage
 
 You can use docx-templates in the browser (yay!). Just as when using docx-templates in Node, you need to provide the template contents as a `Buffer`-like object. 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,5 +47,7 @@ export default [{
 }, {
   input: './lib/index.d.ts',
   output: { file: './lib/bundled.d.ts', format: 'es' },
-  plugins: [dts()]
+  plugins: [
+    dts({ respectExternal: true })
+  ]
 }]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,5 +55,9 @@ export default defineConfig([{
         return 'type Buffer = ArrayBufferLike;\n'+ code.split('\n').slice(1).join('\n')
       }
     }
+  ],
+  external: [
+    // To prevent warning. If `import ... from 'stream'` exists in bundled.d.ts this build has to be changed to remove it.
+    'stream'
   ]
 }])

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,9 @@ import esbuild from 'rollup-plugin-esbuild'
 import node from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import dts from 'rollup-plugin-dts'
+import { defineConfig } from 'rollup'
 
-export default [{
+export default defineConfig([{
   input: './src/browser.ts',
   output: { file: './lib/browser.js', format: 'es', exports: 'named', sourcemap: true },
   plugins: [
@@ -48,6 +49,11 @@ export default [{
   input: './lib/index.d.ts',
   output: { file: './lib/bundled.d.ts', format: 'es' },
   plugins: [
-    dts({ respectExternal: true })
+    dts({ respectExternal: true }),
+    {
+      renderChunk(code) {
+        return 'type Buffer = ArrayBufferLike;\n'+ code.split('\n').slice(1).join('\n')
+      }
+    }
   ]
-}]
+}])


### PR DESCRIPTION
This PR fixes the deno types. There was a mistake (so not all dependencies were bundled). 
The changes to the rollup config:
1. tell dts to include external types
2. renderChunk code to replace first line of .d.ts file with a custom line (From node type include to `type Buffer = ArrayBufferLike` wich is the complete typing  of node stuff we need.)

Sorry that was my mistake in 8ea51acee72f06a3b7762041ac645c4b1e1a0298 didn't test it properly then.