### PR TITLE
clarify that the loop variable must be prefixed with $

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ Loop over a group of elements (resulting from the evaluation of a JavaScript exp
 +++END-FOR person+++
 ```
 
+Note that inside the loop, the variable relative to the current element being processed must be prefixed with `$`.
+
 Since JavaScript expressions are supported, you can for example filter the loop domain:
 
 ```


### PR DESCRIPTION
This is clear from the examples, but can still be a bit confusing because this prefix is not necessary in other templating libraries. For instance, in nunjucks/jinja:

```
{% for person in people %}
{{ person }}
{% endfor %}
```

Thanks for this nice tool!