### PR TITLE
add ability to provide captions for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ The JS snippet must return an _image object_ or a Promise of an _image object_, 
 * `thumbnail` _[optional]_: when injecting an SVG image, a fallback non-SVG (png/jpg/gif, etc.) image can be provided. This thumbnail is used when SVG images are not supported (e.g. older versions of Word) or when the document is previewed by e.g. Windows Explorer. See usage example below.
 * `alt` _[optional]_: optional alt text.
 * `rotation` _[optional]_: optional rotation in degrees, with positive angles moving clockwise.
+* `caption` _[optional]_: optional caption displayed below the image
 
 In the .docx template:
 ```

--- a/examples/example-node/index.js
+++ b/examples/example-node/index.js
@@ -31,7 +31,7 @@ createReport({
     qr: contents => {
       const dataUrl = qrcode(contents, { size: 500 });
       const data = dataUrl.slice('data:image/gif;base64,'.length);
-      return { width: 6, height: 6, data, extension: '.gif' };
+      return { width: 6, height: 6, data, extension: '.gif', caption: 'QR Code caption' };
     },
   },
 }).then(

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export type Context = {
     'w:p': BufferStatus;
     'w:tr': BufferStatus;
   };
-  pendingImageNode?: NonTextNode;
+  pendingImageNode?: { image: NonTextNode; caption?: NonTextNode[] };
   imageId: number;
   images: Images;
   pendingLinkNode?: NonTextNode;
@@ -223,6 +223,11 @@ export type ImagePars = {
    * Optional rotation in degrees, with positive angles moving clockwise.
    */
   rotation?: number;
+
+  /**
+   * Optional caption
+   */
+  caption?: string;
 };
 
 export type LinkPars = {


### PR DESCRIPTION
Added option to provide a caption for an image which will be displayed on the next line (just inserts it ). This resolves #194. 

The caption is inserted just after the drawing with a line break in between. This is slightly different to how Word and LibreOffice implement captions (Word uses a new paragraph and LibreOffice uses a textbox), but it seems to work and requires minimal code changes.