### PR TITLE
Fix END-IF error message for unexpected END-FOR

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -776,13 +776,15 @@ const processEndForIf = (
   cmdName: string,
   cmdRest: string
 ): void => {
+  const isIf = cmdName === 'END-IF';
   const curLoop = getCurLoop(ctx);
   if (!curLoop)
     throw new InvalidCommandError(
-      'Unexpected END-IF outside of IF statement context',
+      `Unexpected ${cmdName} outside of ${
+        isIf ? 'IF' : 'FOR'
+      } statement context`,
       cmd
     );
-  const isIf = cmdName === 'END-IF';
 
   // First time we visit an END-IF node, we assign it the arbitrary name
   // generated when the IF was processed


### PR DESCRIPTION
If a template an errant `END-FOR` command, the current behaviour is to throw an error with the text:

    Unexpected END-IF outside of IF statement context

However, the command isn't an `END-IF` and it isn't within an `IF` context - the message is just hardcoded to state `IF`.

This PR changes the outputted error message to report the command name used and corresponding context.

This can be reproduced with a template like this, with just the following text and nothing else:

```
+++END-FOR person+++
```