### PR TITLE
Fix END-IF error being thrown for END-FOR

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -776,13 +776,15 @@ const processEndForIf = (
   cmdName: string,
   cmdRest: string
 ): void => {
+  const isIf = cmdName === 'END-IF';
   const curLoop = getCurLoop(ctx);
   if (!curLoop)
     throw new InvalidCommandError(
-      'Unexpected END-IF outside of IF statement context',
+      `Unexpected ${cmdName} outside of ${
+        isIf ? 'IF statement' : 'FOR loop'
+      } context`,
       cmd
     );
-  const isIf = cmdName === 'END-IF';
 
   // First time we visit an END-IF node, we assign it the arbitrary name
   // generated when the IF was processed


### PR DESCRIPTION
If a template an errant END-FOR command, the current behaviour is to throw an error with the text:

    Unexpected END-IF outside of IF statement context: end-for person

However, the command message is describes the wrong command/structure used.

This PR changes the outputted error message to report the command name used and corresponding context, working for both END-IF/END-FOR commands.

This can be reproduced with a template like this, with just the following text and nothing else:

    +++END-FOR person+++