### PR TITLE
Change README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Takes the HTML resulting from evaluating a JavaScript snippet and converts it to
 
 ```
 +++HTML `
-<meta charset="UTF-8">
+<meta charset=UTF-8>
 <body>
   <h1>${$film.title}</h1>
   <h3>${$film.releaseDate.slice(0, 4)}</h3>


### PR DESCRIPTION
When I use this code in a DOCX file:

```
<meta charset="UTF-8">
<body>...</body>
```

Special characters don't work (like è), meaning the character encoding isn't right. But if I remove the quotes around "UTF-8" like this:

```
<meta charset=UTF-8>
<body>...</body>
```

It starts working correctly.