### PR TITLE
Add result to ObjectCommandResultError

### DIFF
--- a/src/__tests__/error_handling.test.ts
+++ b/src/__tests__/error_handling.test.ts
@@ -238,6 +238,30 @@ if (process.env.DEBUG) setDebugLogSink(console.log);
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
+  it('attaches the result to ObjectCommandResultError', async () => {
+    const template = await fs.promises.readFile(
+      path.join(__dirname, 'fixtures', 'objectCommandResultError.docx')
+    );
+
+    await expect(
+      createReport({
+        noSandbox,
+        template,
+        data: {
+          companies: {
+            one: 'FIRST',
+            two: 'SECOND',
+            three: 'THIRD',
+          },
+        },
+      })
+    ).rejects.toHaveProperty('result', {
+      one: 'FIRST',
+      two: 'SECOND',
+      three: 'THIRD',
+    });
+  });
+
   it('Incomplete conditional statement: missing END-IF', async () => {
     const template = await fs.promises.readFile(
       path.join(__dirname, 'fixtures', 'missingEndIf.docx')

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,10 +19,12 @@ export class NullishCommandResultError extends Error {
  */
 export class ObjectCommandResultError extends Error {
   command: string;
-  constructor(command: string) {
+  result: any;
+  constructor(command: string, result: any) {
     super(`Result of command '${command}' is an object`);
     Object.setPrototypeOf(this, ObjectCommandResultError.prototype);
     this.command = command;
+    this.result = result;
   }
 }
 

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -580,7 +580,7 @@ const processCmd: CommandProcessor = async (
           return '';
         }
         if (typeof result === 'object' && !Array.isArray(result)) {
-          const nerr = new ObjectCommandResultError(cmdRest);
+          const nerr = new ObjectCommandResultError(cmdRest, result);
           if (ctx.options.errorHandler != null) {
             result = await ctx.options.errorHandler(nerr, cmdRest);
           } else {


### PR DESCRIPTION
When a `ObjectCommandResultError` is thrown, this change attaches the computed result to the error in case a custom error handler wants to use it for some reason.

In my case, I use `Proxy` objects to wrap `Object`s with a `toString()` property that I've been using since 2.9.0 but stopped working with the introduction of object checking and `ObjectCommandResultError`, but this change should allow me to deal with that in a custom error handler.