### PR TITLE
Ability to preprocess XML by developers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -220,7 +220,7 @@ async function createReport(
   if (_probe === 'JS') return report1;
 
   logger.debug('Converting report to XML...');
-  const reportXml = buildXml(report1, xmlOptions);
+  const reportXml = buildXml(options.preProcessXML? options.preProcessXML(report1, "main") : report1 , xmlOptions);
   if (_probe === 'XML') return reportXml;
   logger.debug('Writing report...');
   zipSetText(zip, `${TEMPLATE_PATH}/${mainDocument}`, reportXml);
@@ -245,14 +245,15 @@ async function createReport(
       links: links2,
       htmls: htmls2,
     } = result;
-    const xml = buildXml(report2, xmlOptions);
+    const segments = filePath.split('/');
+    const documentComponent = segments[segments.length - 1];
+
+    const xml = buildXml(options.preProcessXML? options.preProcessXML(report2, documentComponent) : report2, xmlOptions);
     zipSetText(zip, filePath, xml);
 
     numImages += Object.keys(images2).length;
     numHtmls += Object.keys(htmls2).length;
 
-    const segments = filePath.split('/');
-    const documentComponent = segments[segments.length - 1];
     await processImages(images2, documentComponent, zip);
     await processLinks(links2, mainDocument, zip);
     await processHtmls(htmls2, mainDocument, zip);

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,7 +220,7 @@ async function createReport(
   if (_probe === 'JS') return report1;
 
   logger.debug('Converting report to XML...');
-  const reportXml = buildXml(options.preProcessXML? options.preProcessXML(report1, "main") : report1 , xmlOptions);
+  const reportXml = buildXml(options.preProcessXML? options.preProcessXML(report1, "main.xml") : report1 , xmlOptions);
   if (_probe === 'XML') return reportXml;
   logger.debug('Writing report...');
   zipSetText(zip, `${TEMPLATE_PATH}/${mainDocument}`, reportXml);

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,14 @@ export type UserOptions = {
    * (Default: false)
    */
   processLineBreaksAsNewText?: boolean;
+    
+  /**
+   * A function that can be used to process the xml nodes before they are sanitized and converted to string.
+   * This can be used to modify the xml nodes before they are inserted into the docx.
+   * @param node The xml node before being sanitized and converted to string
+   * @returns Node The modified node
+   */
+  preProcessXML?: (node: Node, documentComponent: string) => Node;
 };
 
 export type CreateReportOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export type UserOptions = {
    * A function that can be used to process the xml nodes before they are sanitized and converted to string.
    * This can be used to modify the xml nodes before they are inserted into the docx.
    * @param node The xml node before being sanitized and converted to string
+   * @param documentComponent The document component main.xml, header1.xml, footer1.xml etc.
    * @returns Node The modified node
    */
   preProcessXML?: (node: Node, documentComponent: string) => Node;


### PR DESCRIPTION
Hi, Its a simple couple of lines of readable non-invasive update, that allows developers to pass their function to pre-process the xml.

It is optional but provides developer tools to handle minor changes. I'm using it in production to process rich text data.

It also allows user to extract xml data if its needed for something else. I'm thinking that I will try to see if I can make mamoth take this xml and convert it to HTML for display purposes.

This feature might not work with worker but it will not cause any problem with normal execution.

I haven't written any docs for now. Please let me know if you are interested. I will write docs and examples if you think this is a good, else totally understand if you don't want to merge it.

PS. great work.