### PR TITLE
Added maximumWalkingDepth option for supporting large documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ const report = await createReport({
    * This may be useful if you implement a process timeout instead.
    * (Default: 1,000,000)
    */
-  maximumWalkingDepth?: number;
+  maximumWalkingDepth: 1_000_000;
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ const report = await createReport({
    * Defaults to false.
    */
   fixSmartQuotes: false;
+
+  /**
+   * Maximum loop iterations allowed when walking through the template.
+   * You can increase this to generate reports with large amount of FOR loop elements.
+   * Tip: You can disable infinite loop protection by using the `Infinity` constant.
+   * This may be useful if you implement a process timeout instead.
+   * (Default: 1,000,000)
+   */
+  maximumWalkingDepth?: number;
 });
 ```
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,6 +165,7 @@ async function createReport(
       options.processLineBreaksAsNewText == null
         ? false
         : options.processLineBreaksAsNewText,
+    maximumWalkingDepth: options.maximumWalkingDepth,
   };
   const xmlOptions = { literalXmlDelimiter };
 

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -210,6 +210,7 @@ export async function walkTemplate(
   const errors: Error[] = [];
 
   let loopCount = 0;
+  const maximumWalkingDepth = ctx.options?.maximumWalkingDepth || 1_000_000;
   while (true) {
     const curLoop = getCurLoop(ctx);
     let nextSibling: Node | null = null;
@@ -249,14 +250,14 @@ export async function walkTemplate(
           `=== parent is null, breaking after ${loopCount} loops...`
         );
         break;
-      } else if (loopCount > 1000000) {
+      } else if (loopCount > maximumWalkingDepth) {
         // adding a emergency exit to avoid infit loops
         logger.debug(
           `=== parent is still not null after ${loopCount} loops, something must be wrong ...`,
           debugPrintNode(parent)
         );
         throw new InternalError(
-          'something went wrong with the document. Please review and try again'
+          'infinite loop or massive dataset detected. Please review and try again'
         );
       }
       nodeIn = parent;

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,15 @@ export type UserOptions = {
    * (Default: false)
    */
   processLineBreaksAsNewText?: boolean;
+
+  /**
+   * Maximum loop iterations allowed when walking through the template.
+   * You can increase this to generate reports with large amount of FOR loop elements.
+   * Tip: You can disable infinite loop protection by using the `Infinity` constant.
+   * This may be useful if you implement a process timeout instead.
+   * (Default: 1,000,000)
+   */
+  maximumWalkingDepth?: number;
 };
 
 export type CreateReportOptions = {
@@ -132,6 +141,7 @@ export type CreateReportOptions = {
   errorHandler: ErrorHandler | null;
   fixSmartQuotes: boolean;
   processLineBreaksAsNewText: boolean;
+  maximumWalkingDepth?: number;
 };
 
 export type SandBox = {


### PR DESCRIPTION
This PR implements a new option `maximumWalkingDepth`.
This option replaces the hard-coded `1000000` (1 million) max loop iterations. This loop counting is intended to avoid an infinite loop. I have retained the default behaviour but updated the InternalError message to 'infinite loop or massive dataset detected'. This should make this issue easier to debug.

I have added TS doc comments and updated the README to document this option.
I have also added a `Tip:` to suggest the use of the `Infinity` constant which will disable the infinite loop detection. I intend to use this in combination with a timeout on my node process instead of an arbitrary limit.

## Motivation

When generating a document using a FOR loop with 2000 iterations and each loop inserting (INS) many values, I was able to exceed 1 million loops in the walkTemplate function. This caused a generic 'something went wrong with the document. Please review and try again' error

I appreciate your work on this library!