### PR TITLE
Use Buffer for huge XML support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -169,9 +169,8 @@ async function createReport(
   };
   const xmlOptions = { literalXmlDelimiter };
 
-  const { jsTemplate, mainDocument, zip, contentTypes } = await parseTemplate(
-    template
-  );
+  const { jsTemplate, mainDocument, zip, contentTypes } =
+    await parseTemplate(template);
 
   logger.debug('Preprocessing template...');
   const prepped_template = preprocessTemplate(
@@ -222,7 +221,7 @@ async function createReport(
 
   logger.debug('Converting report to XML...');
   const reportXml = buildXml(report1, xmlOptions);
-  if (_probe === 'XML') return reportXml;
+  if (_probe === 'XML') return reportXml.toString('utf-8');
   logger.debug('Writing report...');
   zipSetText(zip, `${TEMPLATE_PATH}/${mainDocument}`, reportXml);
 
@@ -478,7 +477,7 @@ const processImages = async (
     logger.debug(`Writing image ${imageId} (${imgName})...`);
     const imgPath = `${TEMPLATE_PATH}/media/${imgName}`;
     if (typeof imgData === 'string') {
-      zipSetBase64(zip, imgPath, imgData);
+      zipSetBase64(zip, imgPath, Buffer.from(imgData));
     } else {
       zipSetBinary(zip, imgPath, imgData);
     }
@@ -550,7 +549,7 @@ const processHtmls = async (
       logger.debug(`Writing html ${htmlId} (${htmlName})...`);
       const htmlPath = `${TEMPLATE_PATH}/${htmlName}`;
       htmlFiles.push(`/${htmlPath}`);
-      zipSetText(zip, htmlPath, htmlData);
+      zipSetText(zip, htmlPath, Buffer.from(htmlData));
       addChild(
         rels,
         newNonTextNode('Relationship', {

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -57,7 +57,13 @@ const buildXml = (node: Node, options: XmlOptions, indent: string = '') => {
   let xml = indent.length
     ? ''
     : '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
-  if (node._fTextNode) xml += sanitizeText(node._text, options);
+
+  let xmlBuffer = Buffer.from(xml, 'utf-8');
+  if (node._fTextNode)
+    xmlBuffer = Buffer.concat([
+      xmlBuffer,
+      Buffer.from(sanitizeText(node._text, options)),
+    ]);
   else {
     let attrs = '';
     const nodeAttrs = node._attrs;
@@ -66,18 +72,27 @@ const buildXml = (node: Node, options: XmlOptions, indent: string = '') => {
     });
     const fHasChildren = node._children.length > 0;
     const suffix = fHasChildren ? '' : '/';
-    xml += `\n${indent}<${node._tag}${attrs}${suffix}>`;
+    xmlBuffer = Buffer.concat([
+      xmlBuffer,
+      Buffer.from(`\n${indent}<${node._tag}${attrs}${suffix}>`),
+    ]);
     let fLastChildIsNode = false;
     node._children.forEach(child => {
-      xml += buildXml(child, options, `${indent}  `);
+      xmlBuffer = Buffer.concat([
+        xmlBuffer,
+        buildXml(child, options, `${indent}  `),
+      ]);
       fLastChildIsNode = !child._fTextNode;
     });
     if (fHasChildren) {
       const indent2 = fLastChildIsNode ? `\n${indent}` : '';
-      xml += `${indent2}</${node._tag}>`;
+      xmlBuffer = Buffer.concat([
+        xmlBuffer,
+        Buffer.from(`${indent2}</${node._tag}>`),
+      ]);
     }
   }
-  return xml;
+  return xmlBuffer;
 };
 
 const sanitizeText = (str: string, options: XmlOptions) => {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -7,11 +7,11 @@ const zipGetText = (zip: JSZip, filename: string) => {
   return file_in_zip.async('text');
 };
 
-const zipSetText = (zip: JSZip, filename: string, data: string) =>
-  zip.file(filename, data);
+const zipSetText = (zip: JSZip, filename: string, data: Buffer) =>
+  zip.file(filename, data, { binary: false });
 const zipSetBinary = (zip: JSZip, filename: string, data: ArrayBuffer) =>
   zip.file(filename, data, { binary: true });
-const zipSetBase64 = (zip: JSZip, filename: string, data: string) =>
+const zipSetBase64 = (zip: JSZip, filename: string, data: Buffer) =>
   zip.file(filename, data, { base64: true });
 const zipSave = (zip: JSZip) =>
   zip.generateAsync({


### PR DESCRIPTION
I needed to generate an xml file with a total length greater than v8 allows (38 GB, and v8 only allows you to put 8 in a string), and these changes helped me not catch the “Range Error: Invalid string length” error. 

All tests passed with the exception of 4 tests on error handlers, but this was unrelated to my changes.

If possible, I would like the library to support huge files.