### PR TITLE
feat: improve table row and column deletion logic

### DIFF
--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -306,10 +306,11 @@ export async function walkTemplate(
         // If the last generated output node is a table column, and it is set to be deleted,
         // don't delete if it has a table as a child
         if (tag === 'w:tc' && fRemoveNode) {
-          fRemoveNode =
-            nodeIn._children.filter(
+          fRemoveNode = !(
+            nodeOut._children.filter(
               child => !child._fTextNode && child._tag === 'w:tbl'
-            ).length > 0;
+            ).length > 0
+          );
         }
       }
       // Execute removal, if needed. The node will no longer be part of the output, but

--- a/src/processTemplate.ts
+++ b/src/processTemplate.ts
@@ -293,6 +293,24 @@ export async function walkTemplate(
         const buffers = ctx.buffers[tag];
         fRemoveNode =
           buffers.text === '' && buffers.cmds !== '' && !buffers.fInsertedText;
+
+        // If the last generated output node is a table row, and it is set to be deleted,
+        // don't delete if it has exactly one nested row (i.e. within nested table)
+        if (tag === 'w:tr' && fRemoveNode) {
+          fRemoveNode =
+            nodeIn._children.filter(
+              child => !child._fTextNode && child._tag === 'w:tr'
+            ).length !== 1;
+        }
+
+        // If the last generated output node is a table column, and it is set to be deleted,
+        // don't delete if it has a table as a child
+        if (tag === 'w:tc' && fRemoveNode) {
+          fRemoveNode =
+            nodeIn._children.filter(
+              child => !child._fTextNode && child._tag === 'w:tbl'
+            ).length > 0;
+        }
       }
       // Execute removal, if needed. The node will no longer be part of the output, but
       // the parent will be accessible from the child (so that we can still move up the tree)


### PR DESCRIPTION
Improve table row and column deletion logic #82 

- Prevent deletion of table rows with exactly one nested row
- Prevent deletion of table columns containing a nested table
- This change helps maintain the structure of complex tables
  while still allowing for conditional content removal 