### PR TITLE
FIX: Retain parent FOR loop's $idx variable in IF command content

### DIFF
--- a/src/jsSandbox.ts
+++ b/src/jsSandbox.ts
@@ -30,9 +30,11 @@ export async function runUserJsAndGetRaw(
   };
 
   // Add currently defined vars, including loop vars and the index
-  // of the innermost loop
+  // of the innermost FOR loop
   const curLoop = getCurLoop(ctx);
-  if (curLoop) sandbox.$idx = curLoop.idx;
+  if (curLoop && !curLoop.isIf) {
+    sandbox.$idx = curLoop.idx;
+  }
   Object.keys(ctx.vars).forEach(varName => {
     sandbox[`$${varName}`] = ctx.vars[varName];
   });


### PR DESCRIPTION
As described in the README, the IF command is implemented using a FOR loop with 1 or 0 iterations.

A side-effect of this is that the $idx variable is also reset to 0 within the IF command content. For example:

```
+++FOR value IN ['a', 'b', 'c'] +++
+++INS $idx +++
+++IF value==='c' +++
+++INS $idx +++
+++END-IF +++
+++END-FOR value +++
```

will generate:
```
0
1
2
0
```

when expected output would be:
```
0
1
2
2
```

This pull request changes the behaviour so that the output is as expected and the innermost FOR loop $idx value is retained.