### PR TITLE
fix: Add indentXml and preserveSpace options to minimize the final file size

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,4 @@
-parser: "@typescript-eslint/parser"
+parser: '@typescript-eslint/parser'
 parserOptions:
   project: tsconfig.json
   sourceType: module
@@ -10,10 +10,10 @@ extends:
   - plugin:jest/recommended
   - plugin:prettier/recommended
 plugins:
-  - "@typescript-eslint"
+  - '@typescript-eslint'
   - jest
 rules:
-  eqeqeq: ["error", "allow-null"]
+  eqeqeq: ['error', 'allow-null']
   comma-dangle:
     - error
     - arrays: always-multiline
@@ -27,10 +27,10 @@ rules:
       peerDependencies: true
       optionalDependencies: false
   import/prefer-default-export: off
-  import/no-unused-modules: 
+  import/no-unused-modules:
     - error
     - unusedExports: true
-      ignoreExports: ["./src/index.ts"]
+      ignoreExports: ['./src/index.ts']
   radix: error
   prefer-promise-reject-errors: error
   no-throw-literal: error
@@ -39,6 +39,4 @@ rules:
   dot-notation: error
   no-loop-func: error
   no-extra-bind: error
-  linebreak-style:
-    - error
-    - unix
+  linebreak-style: off

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,6 @@
-singleQuote: true
-trailingComma: es5
-arrowParens: avoid
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "avoid",
+  "endOfLine": "crlf"
+}

--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ const report = await createReport({
    * (Default: 1,000,000)
    */
   maximumWalkingDepth: 1_000_000,
+  /**
+   * Whether to indent the generated XML to make it more human-readable.
+   * Tip: Set this to true if you want to inspect the generated XML or if you want to use a diff tool to compare the generated docx file with another one.
+   * Leaving this option to false will result in a smaller file size.
+   * (Default: false)
+   */
+  indentXml?: boolean;
+  /**
+   * Whether to preserve whitespace in the generated XML.*
+   * Tip: Set this to true if your template contains significant whitespace that you want to preserve in the output document.
+   * Leaving this option to false will result in a smaller file size.
+   * (Default: false)
+   */
+  preserveSpace?: boolean;
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Template-based docx report creation for both Node and the browser. ([See the blog post](http://guigrpa.github.io/2017/01/01/word-docs-the-relay-way/)).
 
+<sub>PS: This is a fork that adds two options to reduce the output file size. It was published to be able to use use before the original author merges the changes. It will be unpublished once the changes are merged.</sub>
 
 ## Why?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "docx-templates",
+  "name": "@zenoo/docx-templates",
   "version": "4.14.1",
-  "description": "Template-based docx report creation",
+  "description": "Template-based docx report creation (fork with new options to reduce the output size)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Guillermo Grau Panea",
@@ -14,13 +14,13 @@
     "report",
     "template"
   ],
-  "homepage": "https://github.com/guigrpa/docx-templates#readme",
+  "homepage": "https://github.com/zenoo/docx-templates#readme",
   "bugs": {
-    "url": "https://github.com/guigrpa/docx-templates/issues"
+    "url": "https://github.com/zenoo/docx-templates/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guigrpa/docx-templates.git"
+    "url": "git+https://github.com/zenoo/docx-templates.git"
   },
   "scripts": {
     "prepare": "yarn compile",

--- a/src/preprocessTemplate.ts
+++ b/src/preprocessTemplate.ts
@@ -4,7 +4,11 @@ import { Node } from './types';
 // In-place
 // In case of split commands (or even split delimiters), joins all the pieces
 // at the starting node
-const preprocessTemplate = (template: Node, delimiter: [string, string]) => {
+const preprocessTemplate = (
+  template: Node,
+  delimiter: [string, string],
+  preserveSpace: boolean
+) => {
   let node: Node | null = template;
   let fCmd = false;
   let openNode = null;
@@ -13,7 +17,7 @@ const preprocessTemplate = (template: Node, delimiter: [string, string]) => {
 
   while (node != null) {
     // Add `xml:space` attr `preserve` to `w:t` tags
-    if (!node._fTextNode && node._tag === 'w:t') {
+    if (preserveSpace && !node._fTextNode && node._tag === 'w:t') {
       node._attrs['xml:space'] = 'preserve';
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,18 @@ export type UserOptions = {
    * (Default: 1,000,000)
    */
   maximumWalkingDepth?: number;
+  /**
+   * Whether to indent the generated XML to make it more human-readable.
+   * Tip: Set this to false if you want to minimize the size of the generated docx file.
+   * (Default: true)
+   */
+  indentXml?: boolean;
+  /**
+   * Whether to preserve whitespace in the generated XML.*
+   * Tip: Set this to false if you want to minimize the size of the generated docx file.
+   * (Default: true)
+   */
+  preserveSpace?: boolean;
 };
 
 export type CreateReportOptions = {
@@ -142,6 +154,8 @@ export type CreateReportOptions = {
   fixSmartQuotes: boolean;
   processLineBreaksAsNewText: boolean;
   maximumWalkingDepth?: number;
+  indentXml: boolean;
+  preserveSpace: boolean;
 };
 
 export type SandBox = {

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -51,6 +51,7 @@ const parseXml = (templateXml: string): Promise<Node> => {
 
 type XmlOptions = {
   literalXmlDelimiter: string;
+  indentXml: boolean;
 };
 
 function buildXml(
@@ -73,14 +74,22 @@ function buildXml(
     });
     const fHasChildren = node._children.length > 0;
     const suffix = fHasChildren ? '' : '/';
-    xmlBuffers.push(Buffer.from(`\n${indent}<${node._tag}${attrs}${suffix}>`));
+
+    // Conditionally add newlines and indentation based on indentXml option
+    const newline = options.indentXml ? `\n${indent}` : '';
+    xmlBuffers.push(Buffer.from(`${newline}<${node._tag}${attrs}${suffix}>`));
+
     let fLastChildIsNode = false;
     node._children.forEach(child => {
-      xmlBuffers.push(buildXml(child, options, `${indent}  `));
+      xmlBuffers.push(
+        buildXml(child, options, options.indentXml ? `${indent}  ` : '')
+      );
       fLastChildIsNode = !child._fTextNode;
     });
     if (fHasChildren) {
-      const indent2 = fLastChildIsNode ? `\n${indent}` : '';
+      // Only add indentation if indentXml is true and last child is a node
+      const indent2 =
+        options.indentXml && fLastChildIsNode ? `\n${indent}` : '';
       xmlBuffers.push(Buffer.from(`${indent2}</${node._tag}>`));
     }
   }


### PR DESCRIPTION
I added the `indentXml` and `preserveSpace` options to be able to reduce the final file size.
They both default to `true` to match the previous process, but they should default to `true` in a later major version in my opinion to have a reduced file sized by default.

I changed the package name to be able to publish the fork while this PR gets approved.
Once it is, I will change the package info back to the original, delete the fork and unpublish it.